### PR TITLE
Assorted fixes

### DIFF
--- a/cache/profile.json
+++ b/cache/profile.json
@@ -1,1 +1,1 @@
-{"app_key":{"key":"mS0xDX2LBVOohjeHW0JsJEBhF","secret":"q54t40D7LQZgQgHScpyXan5YlTxc3qKBu8SbC7w6kH0DsBZcu9"},"profiles":{},"mutes":{"users":{},"tweets":{},"words":[]},"threads":{}}
+{"app_key":{"key":"mS0xDX2LBVOohjeHW0JsJEBhF","secret":"q54t40D7LQZgQgHScpyXan5YlTxc3qKBu8SbC7w6kH0DsBZcu9"},"curr_profile":null,"profiles":{},"mutes":{"users":{},"tweets":{},"words":[]},"threads":{}}

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -561,7 +561,7 @@ pub fn paint(tweeter: &::tw::TwitterCache, display_info: &mut DisplayInfo) -> Re
                     }
                 };
                 for line in to_draw {
-                    print!("{}{}{}", cursor::Goto(1, height - h), clear::CurrentLine, line);
+                    print!("{}{}{}", cursor::Goto(1, height - h), line, clear::UntilNewline);
                     h = h + 1;
                     if h >= height {
                         break;

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -412,7 +412,7 @@ pub fn paint(tweeter: &::tw::TwitterCache, display_info: &mut DisplayInfo) -> Re
             {
                 let to_show = display_info.log[first_tail_log..last_tail_log].iter().rev();
                 for line in to_show {
-                    print!("{}{}{}/{}: {}", cursor::Goto(1, height - i), clear::CurrentLine, display_info.log.len() - 1 - i as usize, display_info.log.len() - 1, line);
+                    print!("{}{}{}/{}: {}", cursor::Goto(1, height - i), clear::CurrentLine, display_info.log.len() - 1 - i as usize, display_info.log.len() - 1, line.chars().take(width.saturating_sub(7) as usize).collect::<String>());
                     i = i + 1;
                 }
             }
@@ -472,7 +472,7 @@ pub fn paint(tweeter: &::tw::TwitterCache, display_info: &mut DisplayInfo) -> Re
                 Some(DisplayMode::Reply(twid, msg)) => {
                     let mut lines: Vec<String> = vec![];
                     lines.push(std::iter::repeat("-").take((width as usize).saturating_sub(2)).collect());
-                    lines.extend(render_twete(&twid, tweeter, display_info, Some(width)));
+                    lines.extend(render_twete(&twid, tweeter, display_info, Some(width - 2)));
                     let reply_delineator = "--------reply";
                     lines.push(format!("{}{}", reply_delineator, std::iter::repeat("-").take((width as usize).saturating_sub(reply_delineator.len() + 2)).collect::<String>()));
                     let msg_lines = into_display_lines(msg.split("\n").map(|x| x.to_owned()).collect(), width - 2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(vec_remove_item)]
 extern crate serde_json;
 
 extern crate chrono;


### PR DESCRIPTION
* fixes default profile.json being incorrect (didn't include curr_profile, so it wouldn't load properly out of the box)
* removes dependence on `remove_item`, and thus permits building on stable rust. partially done because this currently does *not* build on stable due to `ring` not building for reasons i didn't look too much into. it's reported, kind of fixed(?) there, so.
* fixes an issue with status lines that would go beyond end of the line and mess up rendering
* fixes some cases where the display would appear to flicker (clear the remainder of a line *after* drawing text, rather than clear whole line **then** draw)
* changes behaviour of self-replies to not @ you (@'ing yourself in a reply means anyone who follows you sees the conversation, even if they follow no one in the thread. it's just messy.)