### PR TITLE
Command fix

### DIFF
--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -412,7 +412,7 @@ pub fn paint(tweeter: &::tw::TwitterCache, display_info: &mut DisplayInfo) -> Re
             {
                 let to_show = display_info.log[first_tail_log..last_tail_log].iter().rev();
                 for line in to_show {
-                    print!("{}{}{}/{}: {}", cursor::Goto(1, height - i), clear::CurrentLine, display_info.log.len() - 1 - i as usize, display_info.log.len() - 1, line);
+                    print!("{}{}{}/{}: {}", cursor::Goto(1, height - i), clear::CurrentLine, display_info.log.len() - 1 - i as usize, display_info.log.len() - 1, line.take(width - 7);
                     i = i + 1;
                 }
             }
@@ -472,7 +472,7 @@ pub fn paint(tweeter: &::tw::TwitterCache, display_info: &mut DisplayInfo) -> Re
                 Some(DisplayMode::Reply(twid, msg)) => {
                     let mut lines: Vec<String> = vec![];
                     lines.push(std::iter::repeat("-").take((width as usize).saturating_sub(2)).collect());
-                    lines.extend(render_twete(&twid, tweeter, display_info, Some(width)));
+                    lines.extend(render_twete(&twid, tweeter, display_info, Some(width - 2)));
                     let reply_delineator = "--------reply";
                     lines.push(format!("{}{}", reply_delineator, std::iter::repeat("-").take((width as usize).saturating_sub(reply_delineator.len() + 2)).collect::<String>()));
                     let msg_lines = into_display_lines(msg.split("\n").map(|x| x.to_owned()).collect(), width - 2);

--- a/src/tw/mod.rs
+++ b/src/tw/mod.rs
@@ -535,6 +535,8 @@ fn parse_word_command<'a, 'b>(line: &'b str, commands: &[&'a Command]) -> Option
         if cmd.params == 0 {
             if line == cmd.keyword {
                 return Some(("", &cmd));
+            } else if line.starts_with(&format!("{} ", cmd.keyword)) {
+                return Some((line.get((cmd.keyword.len() + 1)..).unwrap().trim(), &cmd));
             }
         } else if line.starts_with(cmd.keyword) {
             if line.find(" ").map(|x| x == cmd.keyword.len()).unwrap_or(false) {


### PR DESCRIPTION
command lines like `t hello world` were being incorrectly rejected because matching no-arg commands expected the rest of the line to be empty.

now `t hello world` operates similarly to `rep 1234 hello world` in that it immediately sends the reply consisting of the string after command+params (eg `hello world` in both cases).

`t` alone and `rep 1234` alone both enter compose mode to prepare a response as normal.