### PR TITLE
clean up DM support, add thing to send DMs

### DIFF
--- a/src/commands/dm.rs
+++ b/src/commands/dm.rs
@@ -1,0 +1,53 @@
+use display::DisplayInfo;
+use tw;
+use ::Queryer;
+
+use tw::TweetId;
+
+use commands::Command;
+
+static DM_CREATE_URL: &str = "https://api.twitter.com/1.1/direct_messages/new.json";
+
+pub static DM: Command = Command {
+    keyword: "dm",
+    params: 1,
+    exec: dm,
+    param_str: " <user_handle>",
+    help_str: "Send DM to <user_handle>"
+};
+
+fn dm(line: String, tweeter: &mut tw::TwitterCache, queryer: &mut Queryer, display_info: &mut DisplayInfo) {
+    let user_profile = match tweeter.current_profile().map(|profile| profile.to_owned()) {
+        Some(profile) => profile,
+        None => {
+            display_info.status("To send a DM you must be an authenticated user.".to_owned());
+            return;
+        }
+    };
+    let mut text: String = line.trim().to_string();
+    let text_bare = match text.find(" ") {
+        None => "".to_owned(),
+        Some(id_end_idx) => {
+            text.split_off(id_end_idx + 1)
+        }
+    };
+    let dm_text = text_bare.trim();
+    let handle_chars = text.trim().chars().collect::<Vec<char>>();
+    let normalized_handle = if handle_chars[0] == '@' {
+        handle_chars[1..].to_vec()
+    } else {
+        handle_chars
+    }.into_iter().collect::<String>();
+
+    let encoded = ::url_encode(dm_text);
+    let result = match tweeter.current_profile() {
+        Some(user_profile) => {
+            queryer.do_api_post(&format!("{}?text={}&screen_name={}", DM_CREATE_URL, encoded, normalized_handle), &tweeter.app_key, &user_profile.creds)
+        },
+        None => Err("No logged in user to DM as".to_owned())
+    };
+    match result {
+        Ok(_) => (),
+        Err(e) => display_info.status(e)
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub struct Command {
     pub help_str: &'static str
 }
 
+pub mod dm;
 pub mod help;
 pub mod auth;
 pub mod show_cache;
@@ -23,6 +24,7 @@ pub mod thread;
 pub mod profile;
 
 pub static COMMANDS: &[&Command] = &[
+    &dm::DM,
     &profile::PROFILE,
     &profile::PROFILES,
     &help::HELP,

--- a/src/tw/mod.rs
+++ b/src/tw/mod.rs
@@ -1200,8 +1200,12 @@ fn handle_twitter_dm(
     display_info: &mut DisplayInfo,
     _queryer: &mut ::Queryer) {
     // show DM
-    display_info.recv(display::Infos::Text(vec![format!("{:?}", structure)]));
-    display_info.recv(display::Infos::DM(structure["direct_message"]["text"].as_str().unwrap().to_string()));
+    tweeter.cache_api_user(structure["direct_message"]["recipient"].clone());
+    tweeter.cache_api_user(structure["direct_message"]["sender"].clone());
+    let dm_text = structure["direct_message"]["text"].as_str().unwrap().to_string();
+    let to = structure["direct_message"]["recipient_id_str"].as_str().unwrap().to_string();
+    let from = structure["direct_message"]["sender_id_str"].as_str().unwrap().to_string();
+    display_info.recv(display::Infos::DM(dm_text, from, to));
 }
 
 fn handle_twitter_welcome(


### PR DESCRIPTION
![selection_486](https://user-images.githubusercontent.com/4615790/34461696-4d1fb4d0-ede6-11e7-8fa0-a6780a97f310.png)

render DMs sanely now, and add a `dm` command used like `dm @whoever the words`. You can omit the leading @, for reasons such as "the API doesn't accept an @ and referencing twitter users without @ is super confusing".

No support for a compose mode or viewing DM history yet.

(the double send on both DMs in the image is because both accounts got the send and receive messages, and there's no solution for duplicate notifications yet)
